### PR TITLE
Handle JSON-wrapped XML input in mcp-app-server

### DIFF
--- a/mcp-app-server/package.json
+++ b/mcp-app-server/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "start": "node src/index.js",
+    "test": "node --test",
     "build:worker": "node src/build-html.js",
     "dev:worker": "npm run build:worker && wrangler dev",
     "deploy": "npm run build:worker && wrangler deploy"

--- a/mcp-app-server/src/normalize-diagram-xml.js
+++ b/mcp-app-server/src/normalize-diagram-xml.js
@@ -1,0 +1,127 @@
+export const INVALID_DIAGRAM_XML_MESSAGE =
+  "Expected draw.io XML. If your host wrapped the payload as JSON text, pass the raw XML string to `xml`.";
+
+/**
+ * Extracts raw draw.io XML from raw XML or common JSON-wrapped text payloads.
+ *
+ * @param {unknown} input
+ * @returns {string|null}
+ */
+export function normalizeDiagramXml(input)
+{
+  function findFirstTextBlock(content)
+  {
+    if (!Array.isArray(content) || content.length === 0)
+    {
+      return null;
+    }
+
+    for (var i = 0; i < content.length; i++)
+    {
+      var block = content[i];
+
+      if (typeof block === "string")
+      {
+        return block;
+      }
+
+      if (block && typeof block.text === "string")
+      {
+        return block.text;
+      }
+    }
+
+    return null;
+  }
+
+  function getXmlCandidate(value)
+  {
+    if (typeof value === "string")
+    {
+      var trimmed = value.trim();
+
+      if (
+        trimmed.length > 0 &&
+        trimmed.charAt(0) === "<" &&
+        (trimmed.indexOf("<mxGraphModel") !== -1 || trimmed.indexOf("<mxfile") !== -1)
+      )
+      {
+        return trimmed;
+      }
+
+      return null;
+    }
+
+    return null;
+  }
+
+  function unwrapOnce(value)
+  {
+    if (typeof value === "string")
+    {
+      var trimmed = value.trim();
+
+      if (trimmed.length === 0)
+      {
+        return null;
+      }
+
+      if (trimmed.charAt(0) === "{" || trimmed.charAt(0) === "[")
+      {
+        try
+        {
+          return JSON.parse(trimmed);
+        }
+        catch (error)
+        {
+          return null;
+        }
+      }
+
+      return null;
+    }
+
+    if (Array.isArray(value))
+    {
+      return findFirstTextBlock(value);
+    }
+
+    if (!value || typeof value !== "object")
+    {
+      return null;
+    }
+
+    if (typeof value.text === "string")
+    {
+      return value.text;
+    }
+
+    if (Array.isArray(value.content))
+    {
+      return findFirstTextBlock(value.content);
+    }
+
+    return null;
+  }
+
+  var current = input;
+
+  for (var depth = 0; depth < 4; depth++)
+  {
+    var xmlCandidate = getXmlCandidate(current);
+
+    if (xmlCandidate)
+    {
+      return xmlCandidate;
+    }
+
+    current = unwrapOnce(current);
+
+    if (current === null)
+    {
+      return null;
+    }
+  }
+
+  return getXmlCandidate(current);
+}

--- a/mcp-app-server/src/shared.js
+++ b/mcp-app-server/src/shared.js
@@ -5,6 +5,7 @@ import {
 } from "@modelcontextprotocol/ext-apps/server";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import { normalizeDiagramXml, INVALID_DIAGRAM_XML_MESSAGE } from "./normalize-diagram-xml.js";
 
 /**
  * Build the self-contained HTML string that renders diagrams.
@@ -109,6 +110,7 @@ export function buildHtml(appWithDepsJs, pakoDeflateJs)
     <!-- MCP Apps SDK (inlined, exports stripped, App alias added) -->
     <script>
 ${appWithDepsJs}
+${normalizeDiagramXml.toString()}
 
 // --- Client-side app logic ---
 
@@ -121,6 +123,7 @@ const fullscreenBtn  = document.getElementById("fullscreen-btn");
 const copyXmlBtn     = document.getElementById("copy-xml-btn");
 var drawioEditUrl = null;
 var currentXml = null;
+var invalidDiagramXmlMessage = ${JSON.stringify(INVALID_DIAGRAM_XML_MESSAGE)};
 
 var app = new App({ name: "draw.io Diagram Viewer", version: "1.0.0" });
 
@@ -226,11 +229,20 @@ app.ontoolresult = function(result)
 
   if (textBlock && textBlock.type === "text")
   {
-    renderDiagram(textBlock.text);
+    var normalizedXml = normalizeDiagramXml(textBlock.text);
+
+    if (normalizedXml)
+    {
+      renderDiagram(normalizedXml);
+    }
+    else
+    {
+      showError(invalidDiagramXmlMessage);
+    }
   }
   else
   {
-    showError("No diagram XML received.");
+    showError(invalidDiagramXmlMessage);
   }
 };
 
@@ -356,7 +368,9 @@ export function createServer(html, serverOptions = {})
     },
     async function({ xml })
     {
-      return { content: [{ type: "text", text: xml }] };
+      var normalizedXml = normalizeDiagramXml(xml);
+
+      return { content: [{ type: "text", text: normalizedXml || xml }] };
     }
   );
 

--- a/mcp-app-server/test/normalize-diagram-xml.test.js
+++ b/mcp-app-server/test/normalize-diagram-xml.test.js
@@ -1,0 +1,57 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { normalizeDiagramXml } from "../src/normalize-diagram-xml.js";
+
+const graphModelXml = '<mxGraphModel dx="1030"></mxGraphModel>';
+const mxFileXml =
+  '<?xml version="1.0" encoding="UTF-8"?><mxfile host="app.diagrams.net"><diagram id="test"><mxGraphModel></mxGraphModel></diagram></mxfile>';
+
+test("returns raw mxGraphModel XML unchanged", function()
+{
+  assert.equal(normalizeDiagramXml(graphModelXml), graphModelXml);
+});
+
+test("returns raw mxfile XML unchanged", function()
+{
+  assert.equal(normalizeDiagramXml(mxFileXml), mxFileXml);
+});
+
+test("unwraps top-level text JSON string", function()
+{
+  assert.equal(
+    normalizeDiagramXml(JSON.stringify({ text: graphModelXml })),
+    graphModelXml
+  );
+});
+
+test("unwraps text content block JSON string", function()
+{
+  assert.equal(
+    normalizeDiagramXml(JSON.stringify({ type: "text", text: graphModelXml })),
+    graphModelXml
+  );
+});
+
+test("unwraps content array JSON string", function()
+{
+  assert.equal(
+    normalizeDiagramXml(JSON.stringify({ content: [{ type: "text", text: graphModelXml }] })),
+    graphModelXml
+  );
+});
+
+test("rejects non-XML text payloads", function()
+{
+  assert.equal(normalizeDiagramXml(JSON.stringify({ text: "hello" })), null);
+});
+
+test("rejects malformed JSON", function()
+{
+  assert.equal(normalizeDiagramXml('{"text":"broken"'), null);
+});
+
+test("rejects empty strings and arrays", function()
+{
+  assert.equal(normalizeDiagramXml("   "), null);
+  assert.equal(normalizeDiagramXml("[]"), null);
+});


### PR DESCRIPTION
## Summary
- add a shared XML normalization helper for `mcp-app-server`
- unwrap common JSON-wrapped text payloads before rendering and before returning tool text content
- add Node-based tests for raw XML, wrapped text payloads, and invalid inputs

## Reproduction
In ChatGPT-style MCP app flows, `create_diagram` can end up receiving or rendering a wrapped payload shaped like:

```json
{"text":"<mxGraphModel ...>...</mxGraphModel>"}
```

The existing code compressed whatever string it received into the `#create=` payload, so wrapped JSON was passed through to `app.diagrams.net` instead of raw diagram XML.

## Root cause
The current implementation did not normalize or reject JSON-wrapped text before:
- returning tool text content from `create_diagram`
- rendering in the iframe
- generating the `Open in draw.io` URL

## Fix
- add `normalizeDiagramXml()` and use it on both the server and iframe side
- accept raw `<mxGraphModel>` / `<mxfile>` as-is
- unwrap common wrappers such as `{"text":"..."}`, `{"type":"text","text":"..."}`, and `{"content":[{"type":"text","text":"..."}]}`
- show a clear UI error when the payload still cannot be resolved to draw.io XML

## Validation
- `cd mcp-app-server && npm test`
- `cd mcp-app-server && npm run build:worker`
- manual helper check with a representative `{"text":"<mxGraphModel...>"}` payload

## Out of scope
- `mcp-tool-server`
- README updates
