### PR TITLE
Add XML fallback for JSON-wrapped create_diagram input

### DIFF
--- a/mcp-app-server/src/normalize-diagram-xml.js
+++ b/mcp-app-server/src/normalize-diagram-xml.js
@@ -1,0 +1,131 @@
+export const INVALID_DIAGRAM_XML_MESSAGE =
+  "Expected draw.io XML. If your host wrapped the payload as JSON text, pass the raw XML string to `xml`.";
+
+/**
+ * Extracts raw draw.io XML from raw XML or common JSON-wrapped text payloads.
+ *
+ * @param {unknown} input
+ * @returns {string|null}
+ */
+export function normalizeDiagramXml(input)
+{
+  function findFirstTextBlock(content)
+  {
+    if (!Array.isArray(content) || content.length === 0)
+    {
+      return null;
+    }
+
+    for (var i = 0; i < content.length; i++)
+    {
+      var block = content[i];
+
+      if (typeof block === "string")
+      {
+        return block;
+      }
+
+      if (block && typeof block.text === "string")
+      {
+        return block.text;
+      }
+    }
+
+    return null;
+  }
+
+  function getXmlCandidate(value)
+  {
+    if (typeof value === "string")
+    {
+      var trimmed = value.trim();
+
+      if (
+        trimmed.length > 0 &&
+        trimmed.charAt(0) === "<" &&
+        (trimmed.indexOf("<mxGraphModel") !== -1 || trimmed.indexOf("<mxfile") !== -1)
+      )
+      {
+        return trimmed;
+      }
+
+      return null;
+    }
+
+    return null;
+  }
+
+  function unwrapOnce(value)
+  {
+    if (typeof value === "string")
+    {
+      var trimmed = value.trim();
+
+      if (trimmed.length === 0)
+      {
+        return null;
+      }
+
+      if (trimmed.charAt(0) === "{" || trimmed.charAt(0) === "[")
+      {
+        try
+        {
+          return JSON.parse(trimmed);
+        }
+        catch (error)
+        {
+          return null;
+        }
+      }
+
+      return null;
+    }
+
+    if (Array.isArray(value))
+    {
+      return findFirstTextBlock(value);
+    }
+
+    if (!value || typeof value !== "object")
+    {
+      return null;
+    }
+
+    if (typeof value.text === "string")
+    {
+      return value.text;
+    }
+
+    if (Array.isArray(value.content))
+    {
+      return findFirstTextBlock(value.content);
+    }
+
+    return null;
+  }
+
+  var current = input;
+
+  for (var depth = 0; depth < 4; depth++)
+  {
+    // Check the current value first so raw XML and partially unwrapped payloads
+    // can return immediately without peeling off another wrapper layer.
+    var xmlCandidate = getXmlCandidate(current);
+
+    if (xmlCandidate)
+    {
+      return xmlCandidate;
+    }
+
+    // Unwrap one layer at a time from common JSON/text envelopes, but stop after
+    // a small fixed number of passes so malformed recursive payloads cannot loop forever.
+    current = unwrapOnce(current);
+
+    if (current === null)
+    {
+      return null;
+    }
+  }
+
+  return getXmlCandidate(current);
+}

--- a/mcp-app-server/src/shared.js
+++ b/mcp-app-server/src/shared.js
@@ -5,6 +5,7 @@ import {
 } from "@modelcontextprotocol/ext-apps/server";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import { normalizeDiagramXml, INVALID_DIAGRAM_XML_MESSAGE } from "./normalize-diagram-xml.js";
 
 /**
  * Build the self-contained HTML string that renders diagrams.
@@ -109,6 +110,7 @@ export function buildHtml(appWithDepsJs, pakoDeflateJs)
     <!-- MCP Apps SDK (inlined, exports stripped, App alias added) -->
     <script>
 ${appWithDepsJs}
+${normalizeDiagramXml.toString()}
 
 // --- Client-side app logic ---
 
@@ -121,6 +123,7 @@ const fullscreenBtn  = document.getElementById("fullscreen-btn");
 const copyXmlBtn     = document.getElementById("copy-xml-btn");
 var drawioEditUrl = null;
 var currentXml = null;
+var invalidDiagramXmlMessage = ${JSON.stringify(INVALID_DIAGRAM_XML_MESSAGE)};
 
 var app = new App({ name: "draw.io Diagram Viewer", version: "1.0.0" });
 
@@ -226,11 +229,20 @@ app.ontoolresult = function(result)
 
   if (textBlock && textBlock.type === "text")
   {
-    renderDiagram(textBlock.text);
+    var normalizedXml = normalizeDiagramXml(textBlock.text);
+
+    if (normalizedXml)
+    {
+      renderDiagram(normalizedXml);
+    }
+    else
+    {
+      showError(invalidDiagramXmlMessage);
+    }
   }
   else
   {
-    showError("No diagram XML received.");
+    showError(invalidDiagramXmlMessage);
   }
 };
 
@@ -356,7 +368,9 @@ export function createServer(html, serverOptions = {})
     },
     async function({ xml })
     {
-      return { content: [{ type: "text", text: xml }] };
+      var normalizedXml = normalizeDiagramXml(xml);
+
+      return { content: [{ type: "text", text: normalizedXml || xml }] };
     }
   );
 


### PR DESCRIPTION
## Summary

Handle JSON-wrapped XML payloads in `mcp-app-server`.

The current `mcp server` implementation works with Claude Code, but it did not work via ChatGPT. In the ChatGPT path, XML that should have been passed through as-is was sometimes transformed into a JSON-like payload before being sent, so the expected diagram data was not ultimately delivered to draw.io.

This change keeps `create_diagram` working when a host sends diagram XML wrapped in a payload such as:

```json
{"text":"<mxGraphModel ...></mxGraphModel>"}
````

## What changed

* normalize wrapped XML before returning tool text content
* normalize wrapped XML before rendering in the app UI
* add a fallback path for cases where ChatGPT sends diagram data in JSON form instead of raw XML

## Scope

* `mcp-app-server` only
* no public API changes

## Output

ChatGPT GPT-5.4 Thinking

https://app.diagrams.net/?pv=0&grid=0#create=%7B%22type%22%3A%22xml%22%2C%22compressed%22%3Atrue%2C%22data%22%3A%225VfLctowFP0a9n6A4y0QaBd0Ji2LLDOydG2rkX09sgg4X18pll%2FYpGHSJouskI7u1eOcoys889fZ6ZskRfoDGYiZ57DTzL%2BdeZ7rOY7%2BMUhVI2EDJJIzG9QBe%2F4MFmzCDpxBOQhUiELxYghSzHOgaoARKfE4DItRDFctSAIjYE%2BJGKP3nKnUom5zDDPwHXiS2qXDhR3ISBNsgTIlDI89yN%2FM%2FLVEVHUrO61BGPIaXuq87YXRdmMScvWWBFIUdcoTEQd7uuXzQYKGlmbM2YN84hTsdlXVcCDxkDMw07gzf3VMuYJ9QagZPWrVNZaqTNjhmAuxRoHyJddnBMKYarxUEh%2BhNxLQEKLYZGCurPBu0PTt6mZGu2uQCk4Xz%2B62jGorAmagZKVDbMLctyJUrS%2Fr%2FrHT1JtbLO3LaTFibZS0U3dM64Yle5r4IhnxfoelSiTsf%2B5GZGubFKZJK8E16%2FLvjEe1PLvoggRxHHt0UgIWRMEiOJNg8X8kcMOhBP6EBG4wIUF71d6jAcUyw3Kkw9rCzu1qJISeQBcZuN7xCwjZfIru0Iv84IPont98Jt0Ck4TnY9%2Fv%2Bvg%2FqjBxSGHa3lG4mOty%2FCF83wSfyTewBB50gX%2BYqDW%2FgDBt8e291KyWY5vr1IYLlCrFBHMiNh266sQxXHYxO8TCEvgblKosw%2BSgcCgY5GxpnmLdjQTSxxractEE1Mo176vXKmL29roe%2Bih4kBTOnjhFZAKqX37HwkkQRPGn4QJTIryk6gOQqhdQIM9V2Zv5zgCdH3xn6Ifmddm%2BMd6%2Fcc4MUO%2Bgs0N7lOsccqESfnWXdLS8wylXX9dLdXKvT26eJV0vv6AWPVY%2B%2BtqG87M%2FiuHr1%2FY8%2Fp3XVne7D4I6vPus8jd%2FAA%3D%3D%22%7D

<img width="1502" height="1299" alt="image" src="https://github.com/user-attachments/assets/1519cd00-14cc-4fe8-ac89-1f79142abce1" />
