### PR TITLE
Update drawio skill: layout guidance + general rules in shared reference

### DIFF
--- a/shared/xml-reference.md
+++ b/shared/xml-reference.md
@@ -38,6 +38,8 @@ Pick a `(col, row)` for each node. Don't think about centers, gaps, or overlap �
 - **Use proper draw.io shapes and connectors** — choose the semantically correct shape for each element (e.g., `shape=cylinder3` for databases and tanks, `rhombus` for decisions, `shape=mxgraph.pid2valves.*` for valves in P&IDs). draw.io has extensive shape libraries; prefer domain-appropriate shapes over generic rectangles.
 - **Decide whether to search for shapes** — before generating a diagram, decide if it needs domain-specific shapes from draw.io's extended libraries. **Skip `search_shapes`** for standard diagram types that use basic geometric shapes: flowcharts, UML (class, sequence, state, activity), ERD, org charts, mind maps, Venn diagrams, timelines, wireframes, and any diagram using only rectangles, diamonds, circles, cylinders, and arrows. Also skip if the user explicitly asks to use basic/simple shapes or says not to search. **Use `search_shapes`** when the diagram requires industry-specific or branded icons: cloud architecture (AWS, Azure, GCP), network topology (Cisco, rack equipment), P&ID (valves, instruments, vessels), electrical/circuit diagrams, Kubernetes, BPMN with specific task types, or any domain where the user expects realistic/standardized symbols rather than labeled boxes.
 - **Match the language of labels to the user's language** — if the user writes in German, French, Japanese, etc., all diagram labels, titles, and annotations should be in that same language.
+- **Group related nodes, and surface a hub when edges converge** — put nodes that belong together inside a container or swimlane, and keep external actors (users, files, third-party systems) outside implementation containers. When many edges converge on one area or cross several groups, route them through a single hub/gateway node (a registry, broker, event log, …) instead of drawing every low-level dependency across the canvas — fewer crossings, clearer contract.
+- **Encode secondary detail in node text, not edges** — draw an edge only when the relationship itself carries meaning; push incidental detail into the node label so the connector layer stays readable.
 
 ## Common styles
 
@@ -146,6 +148,10 @@ Just declare `source` and `target` and let ELK do the routing. The ELK pass also
 - `dashed=1` — dashed line
 - `strokeColor=#...`, `strokeWidth=2` — color/width
 - Edge labels: set `value` directly on the edge cell
+
+**Keep edge labels short and meaningful** — one to three words (`Yes`, `async`, `reads`). Drop labels that merely restate an obvious action (`call`, `register`); move longer explanations into node text or a small legend node.
+
+**Visual semantics — stay consistent, add a legend when mixing styles.** Within one diagram apply `dashed=1`, `strokeColor`, and `strokeWidth` consistently for one chosen meaning (e.g. dashed = optional / async / inferred relationship). Don't mix several dashed meanings without a small legend explaining them.
 
 ## Containers and groups
 
@@ -450,6 +456,10 @@ Every XML diagram rendered in the viewer automatically runs an ELK (Eclipse Layo
 You do not need to request this. Place vertices where they belong and write edges naively — the viewer handles connector cleanup.
 
 This also means: there is no server-side post-processing pass. What you generate is what the viewer starts with; the ELK pass is the only correction.
+
+**This automatic cleanup runs only in the viewer.** A static `.drawio` file — opened in the draw.io desktop app, or exported to PNG/SVG with the desktop CLI (what the skill does) — gets no ELK pass. What you wrote is what renders: nodes stay where you placed them, and each edge gets only its edge style's own routing. Orthogonal edges still bend into right angles, but that router will run a line straight through any node in its way and won't space out parallel edges — and nothing cleans up those tangles afterward.
+
+For static-file output, then: place nodes deliberately (good placement is what keeps edges from crossing), export a preview, and look at it. Add manual routing only for the specific edges that still cut through a node or bundle together — `exitX`/`exitY` plus `entryX`/`entryY` to choose where an edge attaches, or waypoints to force its path. Leave edges that already look clean alone.
 
 ## Post-layout (optional, overrides vertex positions)
 

--- a/skill-cli/drawio/SKILL.md
+++ b/skill-cli/drawio/SKILL.md
@@ -9,13 +9,15 @@ Generate draw.io diagrams as native `.drawio` files. Optionally export to PNG, S
 
 ## How to create a diagram
 
-1. **Generate draw.io XML** in mxGraphModel format for the requested diagram
-2. **Write the XML** to a `.drawio` file in the current working directory using the Write tool
-3. **Handle the requested output format**:
+1. **Plan the layout before XML**: pick a reading direction, group related nodes into containers, and decide which relationships are edges vs. node text (see [Layout and routing quality](#layout-and-routing-quality))
+2. **Generate draw.io XML** in mxGraphModel format for the requested diagram, following [Layout and routing quality](#layout-and-routing-quality) and using [XML reference](#xml-reference) for draw.io syntax details
+3. **Write the XML** to a `.drawio` file in the current working directory using the Write tool
+4. **Handle the requested output format**:
    - `png` / `svg` / `pdf` → locate the draw.io CLI (see [draw.io CLI](#drawio-cli)), export with `--embed-diagram`, then delete the source `.drawio` file. If the CLI is not found, keep the `.drawio` file and tell the user they can install the draw.io desktop app to enable export, or use `url` mode instead, or open the `.drawio` file directly
    - `url` → generate a browser URL from the XML and open it (see [Browser URL output](#browser-url-output)). Keep the `.drawio` file as a persistent local copy
    - *(no format)* → no extra step; the `.drawio` file is the output
-4. **Open the result** — the exported file if exported, the browser URL if `url`, or the `.drawio` file otherwise. If the open command fails, print the file path (or URL) so the user can open it manually
+5. **Export and inspect complex diagrams**: for architecture, flow, network, or diagrams with more than 8 nodes, export a PNG/SVG preview with draw.io CLI when available and visually check it before finalizing
+6. **Open the result** — the exported file if exported, the browser URL if `url`, or the `.drawio` file otherwise. If the open command fails, print the file path (or URL) so the user can open it manually
 
 ## Choosing the output format
 
@@ -223,6 +225,31 @@ cmd.exe /c start "" "$(wslpath -w diagram.drawio)"
 - For export, use double extensions: `name.drawio.png`, `name.drawio.svg`, `name.drawio.pdf` — this signals the file contains embedded diagram XML
 - After a successful export, delete the intermediate `.drawio` file — the exported file contains the full diagram
 - For `url` mode, keep the `.drawio` file (no double extension) — the URL is a view/edit handle and the local file is the persistent copy
+
+## Layout and routing quality
+
+Readability is part of the deliverable — don't finish a complex diagram while the preview shows tangled routing, duplicated titles, labels sitting on nodes, or large blank page areas. The [XML reference](#xml-reference) holds the general rules: reading direction, grouping nodes in containers, routing convergent edges through a hub, short edge labels, and consistent dashed/color semantics. Follow those, plus the two points below that are specific to native `.drawio` output.
+
+### Static files skip the viewer's auto-layout
+
+The XML reference's automatic ELK edge-routing pass is a *viewer* feature. A `.drawio` file opened in the desktop app or exported via the CLI does **not** get it, so here:
+
+- **Vertex positions are final as written** — plan node placement before emitting XML; nothing repositions them afterward.
+- **Limited manual routing is allowed** — `exitX/exitY`, `entryX/entryY`, or waypoints (stagger parallel lines by 10-20 px), but only for edges that still look tangled in a rendered preview. Prefer adding a hub over hand-routing many lines.
+
+### Visual validation loop
+
+For non-trivial diagrams, validate the rendering, not just the XML:
+
+1. Confirm the XML is well-formed and has no duplicate `mxCell` ids.
+2. Export a preview with the draw.io CLI when available:
+
+   ```bash
+   drawio -x -f png -b 10 -o /tmp/diagram-preview.png DIAGRAM.drawio
+   ```
+
+3. Inspect the image for lines crossing through nodes or containers, labels overlapping nodes or each other, dense bundles of unrelated edges in one lane, duplicate or off-page titles, and large blank regions from stray cells.
+4. Iterate until the preview is readable — prefer reducing edges and adding hubs over tweaking individual tangled lines.
 
 ## XML format
 


### PR DESCRIPTION
## Summary
- Add layout-planning and visual-validation guidance to the drawio skill.
- Move the general layout/routing/visual-semantics rules into `shared/xml-reference.md` (the single source of truth): route convergent edges through a hub, keep edge labels short, apply consistent visual semantics, and distinguish the viewer's automatic ELK routing from static-file output.
- Trim the skill to its `.drawio`-specific points — static files skip the viewer's ELK cleanup pass, so node placement is final and limited manual routing is allowed — plus a visual validation loop (export a preview and inspect it).

## Validation
- Generated an architecture diagram with the updated guidance and inspected the exported PNG: clear hubs, a legend, short edge labels, and no tangled routing.
