### PR TITLE
docs: add Cursor setup instructions for both MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repository offers four approaches for integrating draw.io with AI assistant
 | **Requires installation** | No (hosted at `mcp.draw.io`) | Yes (npm package) | One-line plugin install (draw.io Desktop only for PNG/SVG/PDF export) | No — just paste instructions |
 | **Supports XML, CSV, Mermaid** | XML only | ✅ All three | XML only (native format) | ✅ All three |
 | **Editable in draw.io** | Via "Open in draw.io" button | ✅ Directly | ✅ Directly | Via link |
-| **Works with** | Claude.ai, VS Code, any MCP Apps host | Claude Desktop, any MCP client | Claude Code | Claude.ai (with Projects) |
+| **Works with** | Claude.ai, VS Code, Cursor, any MCP Apps host | Claude Desktop, Cursor, any MCP client | Claude Code | Claude.ai (with Projects) |
 | **Best for** | Inline previews in chat | Local desktop workflows | Local development workflows | Quick setup, no install needed |
 
 ---
@@ -28,7 +28,7 @@ The official hosted endpoint is available at:
 https://mcp.draw.io/mcp
 ```
 
-Add this URL as a remote MCP server in Claude.ai or any MCP Apps-compatible host — no installation required.
+Add this URL as a remote MCP server in Claude.ai, Cursor, or any MCP Apps-compatible host — no installation required. In Cursor, diagrams render inline in the Agent chat ([one-click install](https://cursor.com/en/install-mcp?name=drawio&config=eyJ1cmwiOiJodHRwczovL21jcC5kcmF3LmlvL21jcCJ9)).
 
 You can also run the server locally via Node.js or deploy your own instance to Cloudflare Workers.
 
@@ -47,6 +47,8 @@ You can also run the server locally via Node.js or deploy your own instance to C
 The original MCP server that opens diagrams directly in the draw.io editor. Supports XML, CSV, and Mermaid.js formats with lightbox and dark mode options. Published as [`@drawio/mcp`](https://www.npmjs.com/package/@drawio/mcp) on npm.
 
 Quick start: `npx @drawio/mcp`
+
+Setup instructions are available for Claude Desktop, Claude Code, VS Code (GitHub Copilot), and Cursor (with one-click install).
 
 **[Full documentation →](mcp-tool-server/README.md)**
 

--- a/mcp-app-server/README.md
+++ b/mcp-app-server/README.md
@@ -34,9 +34,29 @@ The official draw.io MCP App server is hosted at:
 https://mcp.draw.io/mcp
 ```
 
-Add this URL as a remote MCP server in Claude.ai or any MCP Apps-compatible host — no installation or setup required.
+Add this URL as a remote MCP server in Claude.ai, Cursor, or any MCP Apps-compatible host — no installation or setup required.
 
-> **Note:** This server renders diagrams **inline** via the [MCP Apps](https://modelcontextprotocol.io/docs/extensions/apps) protocol, so it requires an MCP Apps–capable host (e.g. Claude.ai). In hosts that don't support MCP Apps — such as **VS Code / GitHub Copilot**, Cursor, or Claude Code — the tool connects but has nothing to render, so the diagram won't appear. For those clients use the stdio [`@drawio/mcp`](../mcp-tool-server) tool server instead, which opens diagrams in the browser. ChatGPT isn't supported yet: its connectors are remote-only and use OpenAI's own widget format rather than MCP Apps, so the diagram won't render inline — and unlike the editors above, the stdio fallback can't be used.
+> **Note:** This server renders diagrams **inline** via the [MCP Apps](https://modelcontextprotocol.io/docs/extensions/apps) protocol, so it requires an MCP Apps–capable host (e.g. Claude.ai or Cursor). In hosts that don't support MCP Apps — such as **VS Code / GitHub Copilot** or Claude Code — the tool connects but has nothing to render, so the diagram won't appear. For those clients use the stdio [`@drawio/mcp`](../mcp-tool-server) tool server instead, which opens diagrams in the browser. ChatGPT isn't supported yet: its connectors are remote-only and use OpenAI's own widget format rather than MCP Apps, so the diagram won't render inline — and unlike the editors above, the stdio fallback can't be used.
+
+### Using with Cursor
+
+Cursor supports the MCP Apps extension, so diagrams render inline in the Agent chat.
+
+[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en/install-mcp?name=drawio&config=eyJ1cmwiOiJodHRwczovL21jcC5kcmF3LmlvL21jcCJ9)
+
+Click the button above for one-click install, or add the hosted endpoint manually to `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` in your project:
+
+```json
+{
+  "mcpServers": {
+    "drawio": {
+      "url": "https://mcp.draw.io/mcp"
+    }
+  }
+}
+```
+
+Enable the server when prompted (or under **Cursor Settings → MCP**), then ask the Agent to create a diagram.
 
 ## Self-Hosting
 

--- a/mcp-tool-server/README.md
+++ b/mcp-tool-server/README.md
@@ -95,7 +95,28 @@ Add to `.vscode/mcp.json` in your workspace (or run **MCP: Open User Configurati
 
 Then click **Start** above the server entry, **trust** the server when prompted, switch Copilot Chat to **Agent mode**, and make sure the drawio tools are enabled under **Configure Tools** (🔧) in the chat input.
 
-> **Note:** Use this stdio server for VS Code — it opens diagrams in the browser and works with any standard MCP client. The hosted `https://mcp.draw.io/mcp` endpoint is a different server that renders diagrams *inline* via the [MCP Apps](https://modelcontextprotocol.io/docs/extensions/apps) protocol, which Copilot does not yet support. Other clients that use stdio (Cursor, Windsurf, etc.) use the same config shape as above.
+> **Note:** Use this stdio server for VS Code — it opens diagrams in the browser and works with any standard MCP client. The hosted `https://mcp.draw.io/mcp` endpoint is a different server that renders diagrams *inline* via the [MCP Apps](https://modelcontextprotocol.io/docs/extensions/apps) protocol, which Copilot does not yet support. Other clients that use stdio (Windsurf, etc.) use the same config shape as above.
+
+### Cursor
+
+[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en/install-mcp?name=drawio&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsIkBkcmF3aW8vbWNwIl19)
+
+Click the button above for one-click install, or add the server manually to `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` in your project:
+
+```json
+{
+  "mcpServers": {
+    "drawio": {
+      "command": "npx",
+      "args": ["-y", "@drawio/mcp"]
+    }
+  }
+}
+```
+
+Enable the server when prompted (or under **Cursor Settings → MCP**), then ask the Agent to create a diagram — it opens in the draw.io editor in your browser.
+
+> **Tip:** Cursor also supports the [MCP Apps](https://modelcontextprotocol.io/docs/extensions/apps) extension, so the hosted [MCP App Server](../mcp-app-server) at `https://mcp.draw.io/mcp` works in Cursor too, rendering diagrams *inline* in chat instead of opening a browser tab. Use this stdio server if you prefer diagrams to open in the full draw.io editor.
 
 ### Other MCP Clients
 


### PR DESCRIPTION
## Summary

Adds Cursor setup instructions alongside the existing Claude Desktop / Claude Code / VS Code docs:

- **`mcp-tool-server/README.md`** — new **Cursor** configuration section with a one-click "Add to Cursor" install button (official Cursor MCP install deeplink) and manual `~/.cursor/mcp.json` / `.cursor/mcp.json` config, plus a tip pointing to the hosted App Server for inline rendering.
- **`mcp-app-server/README.md`** — new **Using with Cursor** section for the hosted `https://mcp.draw.io/mcp` endpoint. Cursor supports the MCP Apps extension ([Cursor MCP docs](https://cursor.com/docs/context/mcp)), so diagrams render inline in the Agent chat; the note previously listing Cursor among non-MCP-Apps hosts is updated accordingly.
- **Root `README.md`** — comparison table "Works with" row and both server sections now mention Cursor.

The one-click install links use Cursor's official install-mcp deeplink format with base64-encoded server config, and the badge SVG is served from `cursor.com/deeplink/mcp-install-dark.svg`.

## Test plan

- [x] Badge SVG and install-page URLs verified to return HTTP 200
- [x] Base64 configs decode to `{"command":"npx","args":["-y","@drawio/mcp"]}` and `{"url":"https://mcp.draw.io/mcp"}`
- [ ] One-click install of both servers verified end-to-end in Cursor