### PR TITLE
feat(tool-server): add list_pages, get_page, set_page for per-page editing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,4 +38,4 @@ pnpm-lock.yaml
 
 # Claude Code
 .claude/
-test/
+/test/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,16 @@ Searches the draw.io shape library by keywords (same tool as the app server's `s
 
 **Output:** Array of matching shapes with `{style, w, h, title}` — style strings can be used directly in `mxCell` style attributes. Use only for diagrams needing industry-specific icons; skip for standard flowcharts, UML, ERD, and org charts.
 
+### `list_pages` / `get_page` / `set_page`
+
+Page-level access to a local multi-page `.drawio` file, so a large file doesn't need to be loaded whole into context just to inspect or edit one page.
+
+- **`list_pages`**: `{ path: string }` → `[{index, id, name, approxSizeBytes}]` for every page, without decompressing page content
+- **`get_page`**: `{ path: string, page: string }` (`page` is a zero-based index or exact page name) → raw `mxGraphModel` XML for that page
+- **`set_page`**: `{ path: string, page: string, content: string }` → replaces that page's content with new `mxGraphModel` XML, leaving all other pages untouched
+
+**Use case**: Call `list_pages` first on any large multi-page file to find the page you need by name/index, then `get_page`/`set_page` to work on just that page instead of the whole file.
+
 ## Quick Decision Guide
 
 | Need | Use | Reliability |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,10 +93,12 @@ Searches the draw.io shape library by keywords (same tool as the app server's `s
 Page-level access to a local multi-page `.drawio` file, so a large file doesn't need to be loaded whole into context just to inspect or edit one page.
 
 - **`list_pages`**: `{ path: string }` → `[{index, id, name, approxSizeBytes}]` for every page, without decompressing page content
-- **`get_page`**: `{ path: string, page: string }` (`page` is a zero-based index or exact page name) → raw `mxGraphModel` XML for that page
-- **`set_page`**: `{ path: string, page: string, content: string }` → replaces that page's content with new `mxGraphModel` XML, leaving all other pages untouched
+- **`get_page`**: `{ path: string, page: string }` (`page` is a zero-based index, exact page name, or page id) → raw `mxGraphModel` XML for that page
+- **`set_page`**: `{ path: string, page: string, content: string }` → replaces that page's content with new `mxGraphModel` XML (a single `<mxGraphModel>` element, no `<diagram>` tags), leaving all other pages untouched
 
-**Use case**: Call `list_pages` first on any large multi-page file to find the page you need by name/index, then `get_page`/`set_page` to work on just that page instead of the whole file.
+These are the only tools that read/write local files by path; paths must end in `.drawio` or `.xml`.
+
+**Use case**: Call `list_pages` first on any large multi-page file to find the page you need by name/index/id, then `get_page`/`set_page` to work on just that page instead of the whole file.
 
 ## Quick Decision Guide
 

--- a/mcp-tool-server/CLAUDE.md
+++ b/mcp-tool-server/CLAUDE.md
@@ -8,6 +8,7 @@ The original draw.io MCP server. Opens diagrams directly in the draw.io editor v
 |------|---------|
 | `src/index.js` | Single-file server (stdio transport, vanilla JS, no build step) |
 | `src/libavoid-pass.js` | Server-side libavoid edge-routing pass for `open_drawio_xml` (`routing: "libavoid"`) — parses the mxGraphModel XML, runs the shared `computeLibavoidRoutes`, writes waypoints back |
+| `src/pages.js` | Local `.drawio` file page access for `list_pages`/`get_page`/`set_page` — regex-scans `<diagram>` blocks (same tag-boundary technique as `libavoid-pass.js`), decompresses/compresses per-page with `pako` as needed |
 | `vendor/libavoid/` | Vendored libavoid-js **node** build + `libavoid.wasm` (see its README). Loaded by path in plain Node — no inlining/base64 (that's the app server's sandbox concern) |
 
 ## Tools
@@ -33,6 +34,16 @@ Opens draw.io with Mermaid.js syntax. **Recommended default** — handles flowch
 Searches the draw.io shape library (~10,000 shapes) by keywords and returns matching shapes with their exact `style` strings, dimensions, and titles — for feeding industry-specific icons (AWS, Azure, GCP, Cisco, Kubernetes, P&ID, electrical, BPMN) into `open_drawio_xml`. The algorithm is the shared `buildTagMap`/`searchShapes` (canonical in `shared/shape-search.js`, copied into `src/` by `copy-shared`), identical to the app server's.
 
 To keep the npm package lean, the ~4.6 MB `search-index.json` is **not** bundled. It is loaded lazily on the **first** `search_shapes` call and cached in memory for the process lifetime; the tag lookup map is built once at that point. An in-repo checkout reads the local `shape-search/search-index.json` (so dev and tests need no network); a published install fetches it from the CDN (`https://cdn.jsdelivr.net/gh/jgraph/drawio-mcp@main/shape-search/search-index.json`, overridable via `DRAWIO_SHAPE_INDEX_URL`). The tool is always advertised; if the index can't be loaded, the call returns a clear error instead of the tool being hidden.
+
+### `list_pages` / `get_page` / `set_page`
+
+Local-file, page-level access for large multi-page `.drawio` files, so an LLM doesn't have to load the whole file into context to inspect or edit one page.
+
+- **`list_pages(path)`** — returns `[{index, id, name, approxSizeBytes}]` for every `<diagram>` in the file. Regex-scans tag boundaries only; never decompresses page bodies, so it stays cheap even for large files.
+- **`get_page(path, page)`** — returns the raw `mxGraphModel` XML for one page (`page` is a zero-based index or the page's exact `name`), decompressing it first if that page is stored compressed.
+- **`set_page(path, page, content)`** — replaces one page's content with new `mxGraphModel` XML (`content`), re-compressing to match that page's original compression state. Every other page, and the rest of the file, is left byte-for-byte untouched.
+
+Draw.io stores each `<diagram>` body as either plain `mxGraphModel` XML or a base64(`pako.deflateRaw`) blob, independently per page — `src/pages.js` detects which per page (body starts with `<` vs. not) rather than trusting the outer `<mxfile compressed="...">` attribute, since files can mix compression states across pages. Duplicate page names are resolved by erroring with the ambiguous indices rather than guessing.
 
 ## URL Generation
 

--- a/mcp-tool-server/CLAUDE.md
+++ b/mcp-tool-server/CLAUDE.md
@@ -8,7 +8,7 @@ The original draw.io MCP server. Opens diagrams directly in the draw.io editor v
 |------|---------|
 | `src/index.js` | Single-file server (stdio transport, vanilla JS, no build step) |
 | `src/libavoid-pass.js` | Server-side libavoid edge-routing pass for `open_drawio_xml` (`routing: "libavoid"`) — parses the mxGraphModel XML, runs the shared `computeLibavoidRoutes`, writes waypoints back |
-| `src/pages.js` | Local `.drawio` file page access for `list_pages`/`get_page`/`set_page` — regex-scans `<diagram>` blocks (same tag-boundary technique as `libavoid-pass.js`), decompresses/compresses per-page with `pako` as needed |
+| `src/pages.js` | Local `.drawio` file page access for `list_pages`/`get_page`/`set_page` — regex-scans `<diagram>` blocks (same tag-boundary technique as `libavoid-pass.js`), decompresses/compresses per-page with `pako` as needed. Covered by `test/pages.test.js` (`npm test`) |
 | `vendor/libavoid/` | Vendored libavoid-js **node** build + `libavoid.wasm` (see its README). Loaded by path in plain Node — no inlining/base64 (that's the app server's sandbox concern) |
 
 ## Tools
@@ -40,10 +40,12 @@ To keep the npm package lean, the ~4.6 MB `search-index.json` is **not** bundled
 Local-file, page-level access for large multi-page `.drawio` files, so an LLM doesn't have to load the whole file into context to inspect or edit one page.
 
 - **`list_pages(path)`** — returns `[{index, id, name, approxSizeBytes}]` for every `<diagram>` in the file. Regex-scans tag boundaries only; never decompresses page bodies, so it stays cheap even for large files.
-- **`get_page(path, page)`** — returns the raw `mxGraphModel` XML for one page (`page` is a zero-based index or the page's exact `name`), decompressing it first if that page is stored compressed.
+- **`get_page(path, page)`** — returns the raw `mxGraphModel` XML for one page (`page` is a zero-based index, the page's exact `name`, or its `id`), decompressing it first if that page is stored compressed.
 - **`set_page(path, page, content)`** — replaces one page's content with new `mxGraphModel` XML (`content`), re-compressing to match that page's original compression state. Every other page, and the rest of the file, is left byte-for-byte untouched.
 
-Draw.io stores each `<diagram>` body as either plain `mxGraphModel` XML or a base64(`pako.deflateRaw`) blob, independently per page — `src/pages.js` detects which per page (body starts with `<` vs. not) rather than trusting the outer `<mxfile compressed="...">` attribute, since files can mix compression states across pages. Duplicate page names are resolved by erroring with the ambiguous indices rather than guessing.
+Draw.io stores each `<diagram>` body as either plain `mxGraphModel` XML or a base64(`pako.deflateRaw`) blob, independently per page — `src/pages.js` detects which per page (body starts with `<` vs. not) rather than trusting the outer `<mxfile compressed="...">` attribute, since files can mix compression states across pages. Duplicate page names are resolved by erroring with the ambiguous indices rather than guessing (use the index or `id` instead; a page whose name is all digits is parsed as an index, so address it by `id`).
+
+These are the only tools whose arguments touch the local filesystem, so they are deliberately constrained: paths must end in `.drawio` or `.xml` (checked before existence, so arbitrary paths aren't probed); `set_page` content must be a single `<mxGraphModel>` element and is rejected if it contains raw `<diagram>` tags (which would escape the page body and rewrite the file's page structure); decompression is capped at 64 MB against deflate bombs; writes go through a temp file + rename so a crash can't truncate the target. Self-closing `<diagram/>` pages (empty pages) are handled on both read and write.
 
 ## URL Generation
 

--- a/mcp-tool-server/package.json
+++ b/mcp-tool-server/package.json
@@ -11,7 +11,8 @@
     "copy-shared": "cp ../shared/xml-reference.md src/xml-reference.md && cp ../shared/mermaid-reference.md src/mermaid-reference.md && cp ../shared/libavoid-routing.js src/libavoid-routing.js && cp ../shared/shape-search.js src/shape-search.js",
     "start": "node src/index.js",
     "prestart": "npm run copy-shared",
-    "prepack": "npm run copy-shared"
+    "prepack": "npm run copy-shared",
+    "test": "node --test"
   },
   "keywords": [
     "mcp",

--- a/mcp-tool-server/src/index.js
+++ b/mcp-tool-server/src/index.js
@@ -5,6 +5,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { ListToolsRequestSchema, CallToolRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import pako from "pako";
 import { routeXml } from "./libavoid-pass.js";
+import { listPageMeta, readPageXml, writePageXml } from "./pages.js";
 import { spawn } from "child_process";
 import { existsSync, readFileSync, writeFileSync, unlinkSync } from "fs";
 import { join, dirname } from "path";
@@ -350,6 +351,85 @@ const tools =
       required: ["content"],
     },
   },
+  {
+    name: "list_pages",
+    description:
+      "Lists the pages (diagrams) in a local .drawio file without loading full page content. " +
+      "Returns each page's index, id, name, and approximate stored size in bytes. " +
+      "Call this first on large multi-page files before get_page/set_page, so only the " +
+      "page you actually need gets loaded into context.",
+    inputSchema:
+    {
+      type: "object",
+      properties:
+      {
+        path:
+        {
+          type: "string",
+          description: "Absolute or relative path to the local .drawio file.",
+        },
+      },
+      required: ["path"],
+    },
+  },
+  {
+    name: "get_page",
+    description:
+      "Reads one page (diagram) from a local .drawio file and returns its raw mxGraphModel " +
+      "XML, decompressing it first if the file stores that page compressed. " +
+      "Use list_pages first to find the index or name of the page you need.",
+    inputSchema:
+    {
+      type: "object",
+      properties:
+      {
+        path:
+        {
+          type: "string",
+          description: "Absolute or relative path to the local .drawio file.",
+        },
+        page:
+        {
+          type: "string",
+          description:
+            "Which page to read: a zero-based page index (e.g. \"0\") or the page's exact name as shown by list_pages.",
+        },
+      },
+      required: ["path", "page"],
+    },
+  },
+  {
+    name: "set_page",
+    description:
+      "Replaces the content of one page (diagram) in a local .drawio file with new " +
+      "mxGraphModel XML, leaving every other page in the file untouched. Compression of the " +
+      "replaced page matches whatever that page's original compression state was. " +
+      "Use list_pages/get_page first to find the target page.",
+    inputSchema:
+    {
+      type: "object",
+      properties:
+      {
+        path:
+        {
+          type: "string",
+          description: "Absolute or relative path to the local .drawio file.",
+        },
+        page:
+        {
+          type: "string",
+          description:
+            "Which page to replace: a zero-based page index (e.g. \"0\") or the page's exact name as shown by list_pages.",
+        },
+        content:
+        {
+          type: "string",
+          description: "The new page content as plain mxGraphModel XML (uncompressed).",
+        },
+      },
+      required: ["path", "page", "content"],
+    },
+  },
 ];
 
 // search_shapes is always advertised; the index is loaded lazily on first call
@@ -452,6 +532,72 @@ server.setRequestHandler(CallToolRequestSchema, async (request) =>
 
       return {
         content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
+      };
+    }
+
+    if (name === "list_pages" || name === "get_page" || name === "set_page")
+    {
+      const filePath = args?.path;
+
+      if (!filePath)
+      {
+        return {
+          content: [{ type: "text", text: "Error: path parameter is required" }],
+          isError: true,
+        };
+      }
+
+      if (!existsSync(filePath))
+      {
+        return {
+          content: [{ type: "text", text: `Error: file not found: ${filePath}` }],
+          isError: true,
+        };
+      }
+
+      if (name === "list_pages")
+      {
+        const fileText = readFileSync(filePath, "utf8");
+        const meta = listPageMeta(fileText);
+
+        return {
+          content: [{ type: "text", text: JSON.stringify(meta, null, 2) }],
+        };
+      }
+
+      const page = args?.page;
+
+      if (page == null)
+      {
+        return {
+          content: [{ type: "text", text: "Error: page parameter is required" }],
+          isError: true,
+        };
+      }
+
+      if (name === "get_page")
+      {
+        const result = readPageXml(filePath, page);
+
+        return {
+          content: [{ type: "text", text: result.xml }],
+        };
+      }
+
+      const newContent = args?.content;
+
+      if (!newContent)
+      {
+        return {
+          content: [{ type: "text", text: "Error: content parameter is required" }],
+          isError: true,
+        };
+      }
+
+      const result = writePageXml(filePath, page, newContent);
+
+      return {
+        content: [{ type: "text", text: `Updated page ${result.index} ("${result.name}") in ${filePath}.` }],
       };
     }
 

--- a/mcp-tool-server/src/index.js
+++ b/mcp-tool-server/src/index.js
@@ -5,7 +5,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { ListToolsRequestSchema, CallToolRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import pako from "pako";
 import { routeXml } from "./libavoid-pass.js";
-import { listPageMeta, readPageXml, writePageXml } from "./pages.js";
+import { assertPagePath, listPageMeta, readPageXml, writePageXml } from "./pages.js";
 import { spawn } from "child_process";
 import { existsSync, readFileSync, writeFileSync, unlinkSync } from "fs";
 import { join, dirname } from "path";
@@ -366,7 +366,7 @@ const tools =
         path:
         {
           type: "string",
-          description: "Absolute or relative path to the local .drawio file.",
+          description: "Absolute or relative path to the local file. Must end in .drawio or .xml.",
         },
       },
       required: ["path"],
@@ -377,7 +377,7 @@ const tools =
     description:
       "Reads one page (diagram) from a local .drawio file and returns its raw mxGraphModel " +
       "XML, decompressing it first if the file stores that page compressed. " +
-      "Use list_pages first to find the index or name of the page you need.",
+      "Use list_pages first to find the index, name, or id of the page you need.",
     inputSchema:
     {
       type: "object",
@@ -386,13 +386,13 @@ const tools =
         path:
         {
           type: "string",
-          description: "Absolute or relative path to the local .drawio file.",
+          description: "Absolute or relative path to the local file. Must end in .drawio or .xml.",
         },
         page:
         {
           type: "string",
           description:
-            "Which page to read: a zero-based page index (e.g. \"0\") or the page's exact name as shown by list_pages.",
+            "Which page to read: a zero-based page index (e.g. \"0\"), the page's exact name, or the page's id as shown by list_pages.",
         },
       },
       required: ["path", "page"],
@@ -413,18 +413,19 @@ const tools =
         path:
         {
           type: "string",
-          description: "Absolute or relative path to the local .drawio file.",
+          description: "Absolute or relative path to the local file. Must end in .drawio or .xml.",
         },
         page:
         {
           type: "string",
           description:
-            "Which page to replace: a zero-based page index (e.g. \"0\") or the page's exact name as shown by list_pages.",
+            "Which page to replace: a zero-based page index (e.g. \"0\"), the page's exact name, or the page's id as shown by list_pages.",
         },
         content:
         {
           type: "string",
-          description: "The new page content as plain mxGraphModel XML (uncompressed).",
+          description:
+            "The new page content as plain mxGraphModel XML (uncompressed). Must be a single <mxGraphModel> element without any <diagram> tags.",
         },
       },
       required: ["path", "page", "content"],
@@ -546,6 +547,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) =>
           isError: true,
         };
       }
+
+      // Restrict which local files the tools may touch before checking
+      // existence, so arbitrary paths aren't probed at all.
+      assertPagePath(filePath);
 
       if (!existsSync(filePath))
       {

--- a/mcp-tool-server/src/pages.js
+++ b/mcp-tool-server/src/pages.js
@@ -1,0 +1,161 @@
+import { readFileSync, writeFileSync } from "fs";
+import pako from "pako";
+
+const DIAGRAM_RE = /<diagram\b([^>]*?)(?:\/>|>([\s\S]*?)<\/diagram>)/g;
+const ATTR_RE = /([a-zA-Z_:][-a-zA-Z0-9_:.]*)\s*=\s*"([^"]*)"/g;
+
+function parseAttrs(rawAttrs)
+{
+  const attrs = {};
+  let match;
+
+  ATTR_RE.lastIndex = 0;
+  while ((match = ATTR_RE.exec(rawAttrs)) !== null)
+  {
+    attrs[match[1]] = match[2];
+  }
+
+  return attrs;
+}
+
+export function parseDiagrams(mxfileText)
+{
+  const diagrams = [];
+  let match;
+  let index = 0;
+
+  DIAGRAM_RE.lastIndex = 0;
+  while ((match = DIAGRAM_RE.exec(mxfileText)) !== null)
+  {
+    diagrams.push({
+      index: index++,
+      attrs: parseAttrs(match[1]),
+      body: match[2] || "",
+      start: match.index,
+      end: match.index + match[0].length,
+    });
+  }
+
+  return diagrams;
+}
+
+export function listPageMeta(mxfileText)
+{
+  return parseDiagrams(mxfileText).map(function (diagram)
+  {
+    return {
+      index: diagram.index,
+      id: diagram.attrs.id || null,
+      name: diagram.attrs.name || null,
+      approxSizeBytes: Buffer.byteLength(diagram.body, "utf8"),
+    };
+  });
+}
+
+export function isLikelyCompressed(body)
+{
+  const trimmed = body.trim();
+  return trimmed.length > 0 && !trimmed.startsWith("<");
+}
+
+export function decompressDiagram(body)
+{
+  const trimmed = body.trim();
+
+  if (!isLikelyCompressed(trimmed))
+  {
+    return trimmed;
+  }
+
+  try
+  {
+    const inflated = pako.inflateRaw(Buffer.from(trimmed, "base64"), { to: "string" });
+    return decodeURIComponent(inflated);
+  }
+  catch (e)
+  {
+    throw new Error(`Failed to decompress page content: ${e.message}`);
+  }
+}
+
+function compressDiagram(xml)
+{
+  const encoded = encodeURIComponent(xml);
+  const compressed = pako.deflateRaw(encoded);
+  return Buffer.from(compressed).toString("base64");
+}
+
+export function findPage(diagrams, indexOrName)
+{
+  const asString = String(indexOrName);
+
+  if (/^\d+$/.test(asString))
+  {
+    const idx = Number.parseInt(asString, 10);
+
+    if (idx < 0 || idx >= diagrams.length)
+    {
+      throw new Error(`Page index ${idx} out of range (file has ${diagrams.length} page${diagrams.length === 1 ? "" : "s"})`);
+    }
+
+    return diagrams[idx];
+  }
+
+  const matches = diagrams.filter(function (diagram)
+  {
+    return diagram.attrs.name === asString;
+  });
+
+  if (matches.length === 0)
+  {
+    const names = diagrams.map(function (diagram) { return diagram.attrs.name; }).join(", ");
+    throw new Error(`No page named "${asString}" found. Available page names: ${names}`);
+  }
+
+  if (matches.length > 1)
+  {
+    const indices = matches.map(function (diagram) { return diagram.index; }).join(", ");
+    throw new Error(`Multiple pages named "${asString}" found (indices: ${indices}). Use an index instead.`);
+  }
+
+  return matches[0];
+}
+
+export function readPageXml(filePath, indexOrName)
+{
+  const text = readFileSync(filePath, "utf8");
+  const diagrams = parseDiagrams(text);
+  const page = findPage(diagrams, indexOrName);
+  const xml = decompressDiagram(page.body);
+
+  return { xml, index: page.index, id: page.attrs.id || null, name: page.attrs.name || null };
+}
+
+export function writePageXml(filePath, indexOrName, newXml)
+{
+  const text = readFileSync(filePath, "utf8");
+  const diagrams = parseDiagrams(text);
+  const page = findPage(diagrams, indexOrName);
+
+  const trimmedXml = newXml.trim();
+
+  if (!trimmedXml.startsWith("<mxGraphModel"))
+  {
+    throw new Error("set_page content must be plain <mxGraphModel> XML for a single page, not a full <mxfile> or non-XML content");
+  }
+
+  const compressed = isLikelyCompressed(page.body);
+  const newBody = compressed ? compressDiagram(trimmedXml) : trimmedXml;
+
+  const fullOriginal = text.slice(page.start, page.end);
+  const bodyStartOffset = fullOriginal.indexOf(">") + 1;
+  const bodyEndOffset = fullOriginal.lastIndexOf("</diagram>");
+  const openingTag = fullOriginal.slice(0, bodyStartOffset);
+  const closingTag = fullOriginal.slice(bodyEndOffset);
+  const replacement = openingTag + newBody + closingTag;
+
+  const result = text.slice(0, page.start) + replacement + text.slice(page.end);
+  writeFileSync(filePath, result, "utf8");
+
+  return { index: page.index, id: page.attrs.id || null, name: page.attrs.name || null, compressed };
+}

--- a/mcp-tool-server/src/pages.js
+++ b/mcp-tool-server/src/pages.js
@@ -1,8 +1,22 @@
-import { readFileSync, writeFileSync } from "fs";
+import { readFileSync, writeFileSync, renameSync, unlinkSync } from "fs";
 import pako from "pako";
 
 const DIAGRAM_RE = /<diagram\b([^>]*?)(?:\/>|>([\s\S]*?)<\/diagram>)/g;
 const ATTR_RE = /([a-zA-Z_:][-a-zA-Z0-9_:.]*)\s*=\s*"([^"]*)"/g;
+
+// Cap on decompressed page size so a crafted deflate bomb in a local file
+// can't OOM the server process.
+const MAX_INFLATED_BYTES = 64 * 1024 * 1024;
+
+export function assertPagePath(filePath)
+{
+  const lower = String(filePath).toLowerCase();
+
+  if (!lower.endsWith(".drawio") && !lower.endsWith(".xml"))
+  {
+    throw new Error(`Only .drawio and .xml files are supported: ${filePath}`);
+  }
+}
 
 function parseAttrs(rawAttrs)
 {
@@ -58,7 +72,35 @@ export function isLikelyCompressed(body)
   return trimmed.length > 0 && !trimmed.startsWith("<");
 }
 
-export function decompressDiagram(body)
+function inflateRawCapped(input, maxBytes)
+{
+  const inflator = new pako.Inflate({ raw: true });
+  const chunks = [];
+  let total = 0;
+
+  inflator.onData = function (chunk)
+  {
+    total += chunk.length;
+
+    if (total > maxBytes)
+    {
+      throw new Error(`decompressed page exceeds the ${maxBytes} byte limit`);
+    }
+
+    chunks.push(Buffer.from(chunk));
+  };
+
+  inflator.push(input, true);
+
+  if (inflator.err)
+  {
+    throw new Error(inflator.msg || "invalid compressed data");
+  }
+
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+export function decompressDiagram(body, maxBytes = MAX_INFLATED_BYTES)
 {
   const trimmed = body.trim();
 
@@ -69,7 +111,7 @@ export function decompressDiagram(body)
 
   try
   {
-    const inflated = pako.inflateRaw(Buffer.from(trimmed, "base64"), { to: "string" });
+    const inflated = inflateRawCapped(Buffer.from(trimmed, "base64"), maxBytes);
     return decodeURIComponent(inflated);
   }
   catch (e)
@@ -85,9 +127,9 @@ function compressDiagram(xml)
   return Buffer.from(compressed).toString("base64");
 }
 
-export function findPage(diagrams, indexOrName)
+export function findPage(diagrams, pageRef)
 {
-  const asString = String(indexOrName);
+  const asString = String(pageRef);
 
   if (/^\d+$/.test(asString))
   {
@@ -101,41 +143,69 @@ export function findPage(diagrams, indexOrName)
     return diagrams[idx];
   }
 
-  const matches = diagrams.filter(function (diagram)
+  let matches = diagrams.filter(function (diagram)
   {
     return diagram.attrs.name === asString;
   });
 
   if (matches.length === 0)
   {
+    matches = diagrams.filter(function (diagram)
+    {
+      return diagram.attrs.id === asString;
+    });
+  }
+
+  if (matches.length === 0)
+  {
     const names = diagrams.map(function (diagram) { return diagram.attrs.name; }).join(", ");
-    throw new Error(`No page named "${asString}" found. Available page names: ${names}`);
+    throw new Error(`No page with name or id "${asString}" found. Available page names: ${names}`);
   }
 
   if (matches.length > 1)
   {
     const indices = matches.map(function (diagram) { return diagram.index; }).join(", ");
-    throw new Error(`Multiple pages named "${asString}" found (indices: ${indices}). Use an index instead.`);
+    throw new Error(`Multiple pages named "${asString}" found (indices: ${indices}). Use an index or page id instead.`);
   }
 
   return matches[0];
 }
 
-export function readPageXml(filePath, indexOrName)
+function writeFileAtomic(filePath, data)
 {
+  const tmpPath = `${filePath}.${process.pid}.tmp`;
+
+  try
+  {
+    writeFileSync(tmpPath, data, "utf8");
+    renameSync(tmpPath, filePath);
+  }
+  catch (e)
+  {
+    try { unlinkSync(tmpPath); } catch (e2) { /* ignore */ }
+    throw e;
+  }
+}
+
+export function readPageXml(filePath, pageRef)
+{
+  assertPagePath(filePath);
+
   const text = readFileSync(filePath, "utf8");
   const diagrams = parseDiagrams(text);
-  const page = findPage(diagrams, indexOrName);
+  const page = findPage(diagrams, pageRef);
   const xml = decompressDiagram(page.body);
 
   return { xml, index: page.index, id: page.attrs.id || null, name: page.attrs.name || null };
 }
 
-export function writePageXml(filePath, indexOrName, newXml)
+export function writePageXml(filePath, pageRef, newXml)
 {
+  assertPagePath(filePath);
+
   const text = readFileSync(filePath, "utf8");
   const diagrams = parseDiagrams(text);
-  const page = findPage(diagrams, indexOrName);
+  const page = findPage(diagrams, pageRef);
 
   const trimmedXml = newXml.trim();
 
@@ -144,18 +214,32 @@ export function writePageXml(filePath, indexOrName, newXml)
     throw new Error("set_page content must be plain <mxGraphModel> XML for a single page, not a full <mxfile> or non-XML content");
   }
 
+  // A raw <diagram> tag in the content would escape the target page's body
+  // and rewrite the file's page structure (escaped &lt;diagram&gt; is fine).
+  if (/<\/?diagram\b/i.test(trimmedXml))
+  {
+    throw new Error("set_page content must not contain <diagram> tags — pass the inner mxGraphModel XML of a single page");
+  }
+
   const compressed = isLikelyCompressed(page.body);
   const newBody = compressed ? compressDiagram(trimmedXml) : trimmedXml;
 
   const fullOriginal = text.slice(page.start, page.end);
-  const bodyStartOffset = fullOriginal.indexOf(">") + 1;
-  const bodyEndOffset = fullOriginal.lastIndexOf("</diagram>");
-  const openingTag = fullOriginal.slice(0, bodyStartOffset);
-  const closingTag = fullOriginal.slice(bodyEndOffset);
-  const replacement = openingTag + newBody + closingTag;
+  let replacement;
+
+  if (fullOriginal.endsWith("/>"))
+  {
+    replacement = `${fullOriginal.slice(0, -2)}>${newBody}</diagram>`;
+  }
+  else
+  {
+    const bodyStartOffset = fullOriginal.indexOf(">") + 1;
+    const bodyEndOffset = fullOriginal.lastIndexOf("</diagram>");
+    replacement = fullOriginal.slice(0, bodyStartOffset) + newBody + fullOriginal.slice(bodyEndOffset);
+  }
 
   const result = text.slice(0, page.start) + replacement + text.slice(page.end);
-  writeFileSync(filePath, result, "utf8");
+  writeFileAtomic(filePath, result);
 
   return { index: page.index, id: page.attrs.id || null, name: page.attrs.name || null, compressed };
 }

--- a/mcp-tool-server/test/pages.test.js
+++ b/mcp-tool-server/test/pages.test.js
@@ -1,0 +1,169 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import pako from "pako";
+import {
+  assertPagePath,
+  parseDiagrams,
+  listPageMeta,
+  decompressDiagram,
+  findPage,
+  readPageXml,
+  writePageXml,
+} from "../src/pages.js";
+
+const PAGE1_XML = '<mxGraphModel><root><mxCell id="0"/><mxCell id="1" parent="0"/></root></mxGraphModel>';
+const PAGE2_XML = '<mxGraphModel><root><mxCell id="0"/><mxCell id="2" parent="0" value="two"/></root></mxGraphModel>';
+
+function compress(xml)
+{
+  return Buffer.from(pako.deflateRaw(encodeURIComponent(xml))).toString("base64");
+}
+
+function makeFile(name, content)
+{
+  const dir = mkdtempSync(join(tmpdir(), "drawio-pages-"));
+  const filePath = join(dir, name);
+  writeFileSync(filePath, content, "utf8");
+  return filePath;
+}
+
+const MIXED_FILE =
+  '<mxfile host="app.diagrams.net" modified="2026-01-01T00:00:00.000Z">' +
+  `<diagram id="id-one" name="First">${PAGE1_XML}</diagram>` +
+  `<diagram id="id-two" name="2">${compress(PAGE2_XML)}</diagram>` +
+  '<diagram id="id-three" name="Empty"/>' +
+  "</mxfile>";
+
+test("listPageMeta returns index, id, name, size for every page", function ()
+{
+  const meta = listPageMeta(MIXED_FILE);
+
+  assert.equal(meta.length, 3);
+  assert.deepEqual(meta.map(function (m) { return m.id; }), ["id-one", "id-two", "id-three"]);
+  assert.deepEqual(meta.map(function (m) { return m.name; }), ["First", "2", "Empty"]);
+  assert.equal(meta[0].approxSizeBytes, Buffer.byteLength(PAGE1_XML, "utf8"));
+  assert.equal(meta[2].approxSizeBytes, 0);
+});
+
+test("readPageXml resolves by index, name, and id", function ()
+{
+  const filePath = makeFile("mixed.drawio", MIXED_FILE);
+
+  assert.equal(readPageXml(filePath, "0").xml, PAGE1_XML);
+  assert.equal(readPageXml(filePath, "First").xml, PAGE1_XML);
+  assert.equal(readPageXml(filePath, "id-one").xml, PAGE1_XML);
+});
+
+test("readPageXml decompresses a compressed page", function ()
+{
+  const filePath = makeFile("mixed.drawio", MIXED_FILE);
+
+  assert.equal(readPageXml(filePath, "1").xml, PAGE2_XML);
+});
+
+test("a page with a numeric name is reachable via its id", function ()
+{
+  const filePath = makeFile("mixed.drawio", MIXED_FILE);
+
+  // "2" is parsed as an index (the Empty page), but id still works.
+  assert.equal(readPageXml(filePath, "2").xml, "");
+  assert.equal(readPageXml(filePath, "id-two").xml, PAGE2_XML);
+});
+
+test("findPage errors on out-of-range index, unknown name, duplicate names", function ()
+{
+  const diagrams = parseDiagrams(MIXED_FILE);
+
+  assert.throws(function () { findPage(diagrams, "3"); }, /out of range/);
+  assert.throws(function () { findPage(diagrams, "Nope"); }, /No page with name or id/);
+
+  const dupes = parseDiagrams(
+    '<mxfile><diagram id="a" name="Same"/><diagram id="b" name="Same"/></mxfile>');
+  assert.throws(function () { findPage(dupes, "Same"); }, /Multiple pages named "Same".*indices: 0, 1/);
+});
+
+test("writePageXml replaces one page and leaves the rest byte-identical", function ()
+{
+  const filePath = makeFile("mixed.drawio", MIXED_FILE);
+  const newXml = '<mxGraphModel><root><mxCell id="0"/><mxCell id="9" parent="0"/></root></mxGraphModel>';
+
+  const result = writePageXml(filePath, "First", newXml);
+  assert.equal(result.compressed, false);
+
+  const text = readFileSync(filePath, "utf8");
+  assert.equal(text, MIXED_FILE.replace(PAGE1_XML, newXml));
+  assert.equal(readPageXml(filePath, "id-two").xml, PAGE2_XML);
+});
+
+test("writePageXml keeps a compressed page compressed", function ()
+{
+  const filePath = makeFile("mixed.drawio", MIXED_FILE);
+  const newXml = '<mxGraphModel><root><mxCell id="0"/></root></mxGraphModel>';
+
+  const result = writePageXml(filePath, "id-two", newXml);
+  assert.equal(result.compressed, true);
+
+  const page = parseDiagrams(readFileSync(filePath, "utf8"))[1];
+  assert.ok(!page.body.startsWith("<"), "body should still be compressed");
+  assert.equal(readPageXml(filePath, "id-two").xml, newXml);
+});
+
+test("writePageXml handles self-closing <diagram/> pages without corrupting the file", function ()
+{
+  const filePath = makeFile("mixed.drawio", MIXED_FILE);
+  const newXml = '<mxGraphModel><root><mxCell id="0"/></root></mxGraphModel>';
+
+  writePageXml(filePath, "Empty", newXml);
+
+  const meta = listPageMeta(readFileSync(filePath, "utf8"));
+  assert.equal(meta.length, 3);
+  assert.equal(readPageXml(filePath, "Empty").xml, newXml);
+  assert.equal(readPageXml(filePath, "First").xml, PAGE1_XML);
+});
+
+test("writePageXml rejects content that is not a single mxGraphModel", function ()
+{
+  const filePath = makeFile("mixed.drawio", MIXED_FILE);
+
+  assert.throws(function ()
+  {
+    writePageXml(filePath, "First", "<mxfile><diagram>x</diagram></mxfile>");
+  }, /must be plain <mxGraphModel> XML/);
+});
+
+test("writePageXml rejects content containing <diagram> tags (structure injection)", function ()
+{
+  const filePath = makeFile("mixed.drawio", MIXED_FILE);
+  const injection = `${PAGE1_XML}</diagram><diagram name="evil">payload`;
+
+  assert.throws(function ()
+  {
+    writePageXml(filePath, "First", injection);
+  }, /must not contain <diagram> tags/);
+
+  assert.equal(readFileSync(filePath, "utf8"), MIXED_FILE);
+});
+
+test("assertPagePath only allows .drawio and .xml files", function ()
+{
+  assertPagePath("/tmp/a.drawio");
+  assertPagePath("/tmp/b.XML");
+  assert.throws(function () { assertPagePath("/etc/passwd"); }, /Only .drawio and .xml/);
+  assert.throws(function () { assertPagePath("notes.txt"); }, /Only .drawio and .xml/);
+});
+
+test("decompressDiagram enforces the inflated size cap", function ()
+{
+  const big = `<mxGraphModel>${"x".repeat(4096)}</mxGraphModel>`;
+
+  assert.equal(decompressDiagram(compress(big)), big);
+  assert.throws(function () { decompressDiagram(compress(big), 1024); }, /exceeds the 1024 byte limit/);
+});
+
+test("decompressDiagram reports invalid data as a clean error", function ()
+{
+  assert.throws(function () { decompressDiagram("not-base64-deflate!!"); }, /Failed to decompress/);
+});


### PR DESCRIPTION
Until now the only tools (open_drawio_xml, open_drawio_csv,
open_drawio_mermaid) operate on the whole file as one XML blob,
so touching a single page in a large multi-page .drawio file
pulls the entire file into context.

Three new tools work at the page level instead:

- list_pages: regex-scans <diagram> tags to return index/id/name/
  size without decompressing page content — stays cheap on large
  files regardless of how many pages or how compressed they are.
- get_page: returns the XML for one page by index or name,
  decompressing on the fly if that page is stored compressed.
- set_page: writes new XML into exactly one page, leaving every
  other page byte-for-byte identical.

The regex scan is safe here because <diagram> blocks in a .drawio
file never nest; no full XML parser dependency is added. Per-page
compression is handled with pako (already a dependency); draw.io
can mix compressed and uncompressed pages in the same file, so
get_page and set_page handle both.

All new logic lives in mcp-tool-server/src/pages.js, kept separate
from index.js so it can be tested in isolation. index.js adds three
tool entries and a new branch in the call handler.

Updated CLAUDE.md (root and mcp-tool-server/) to document the new
tools alongside the existing ones.