### PR TITLE
docs: note Cursor >=2.6 requirement and stdio fallback for inline rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The official hosted endpoint is available at:
 https://mcp.draw.io/mcp
 ```
 
-Add this URL as a remote MCP server in Claude.ai, Cursor, or any MCP Apps-compatible host — no installation required. In Cursor, diagrams render inline in the Agent chat ([one-click install](https://cursor.com/en/install-mcp?name=drawio&config=eyJ1cmwiOiJodHRwczovL21jcC5kcmF3LmlvL21jcCJ9)).
+Add this URL as a remote MCP server in Claude.ai, Cursor, or any MCP Apps-compatible host — no installation required. In Cursor (≥ 2.6), diagrams render inline in the Agent chat ([one-click install](https://cursor.com/en/install-mcp?name=drawio&config=eyJ1cmwiOiJodHRwczovL21jcC5kcmF3LmlvL21jcCJ9)); on older builds, use the stdio [`@drawio/mcp`](mcp-tool-server/README.md) tool server instead.
 
 You can also run the server locally via Node.js or deploy your own instance to Cloudflare Workers.
 

--- a/mcp-app-server/README.md
+++ b/mcp-app-server/README.md
@@ -40,7 +40,7 @@ Add this URL as a remote MCP server in Claude.ai, Cursor, or any MCP Apps-compat
 
 ### Using with Cursor
 
-Cursor supports the MCP Apps extension, so diagrams render inline in the Agent chat.
+Cursor supports the MCP Apps extension (Cursor **≥ 2.6**), so diagrams render inline in the Agent chat. On older builds the server still connects, but there's nothing to render inline; use the stdio [`@drawio/mcp`](../mcp-tool-server) tool server instead, which opens diagrams in the browser.
 
 [![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en/install-mcp?name=drawio&config=eyJ1cmwiOiJodHRwczovL21jcC5kcmF3LmlvL21jcCJ9)
 


### PR DESCRIPTION
Follow-up to #51, addressing @alderg's two non-blocking review notes.

## What changed

- **Version floor** (review note 2): the app-server and root READMEs now state that inline rendering needs **Cursor ≥ 2.6** (MCP Apps support shipped in Cursor 2.6, March 3, 2026). Older builds connect but render nothing inline.
- **stdio fallback pointer** (mitigation for review note 1): both sections now point users on older Cursor builds to the stdio [`@drawio/mcp`](../mcp-tool-server) tool server, which opens diagrams in the browser. This gives a working path if inline rendering isn't available.

## Notes

- The end-to-end inline-render check in Cursor 2.6+ (the last unchecked box in #51's test plan) is a runtime verification and isn't covered by these doc changes. Happy to update wording further once someone confirms the `https://mcp.draw.io/mcp` → "ask for a diagram" flow renders inline in Cursor's sandbox.

## Test plan

- [x] Markdown links resolve to existing paths (`mcp-tool-server`)
- [ ] Inline render confirmed in Cursor ≥ 2.6 end-to-end