### PR TITLE
docs: add rendered diagram quality gate

### DIFF
--- a/plugins/claude-code/skills/drawio/SKILL.md
+++ b/plugins/claude-code/skills/drawio/SKILL.md
@@ -35,12 +35,13 @@ Every diagram becomes a native `.drawio` file first, then is delivered in the re
    - **XML**: write the mxGraphModel XML to `diagram.drawio` (see [XML format](#xml-format)). Optionally apply an ELK layout (see [ELK layout for XML](#elk-layout-for-xml)).
 2. **Deliver** (identical for both sources):
    - *(no format)* → keep `diagram.drawio` and open it.
-   - **png / svg / pdf** → export from the `.drawio` with embedded XML, then delete the source `.drawio`:
+   - **png / svg / pdf** → export from the `.drawio` with embedded XML. Keep the source until visual validation passes, then delete it:
      ```bash
      drawio -x -f png -e -b 10 -o diagram.drawio.png diagram.drawio
      ```
    - **url** → build a browser URL from the `.drawio` XML, open it, and keep the `.drawio` as a local copy (see [Browser URL output](#browser-url-output)).
 3. **Open the result** — the exported file, the URL, or the `.drawio`. If the open command fails, print the absolute path (or URL) so the user can open it manually.
+4. **Visually validate non-trivial diagrams** — inspect the rendered result before reporting completion. Confirm that connectors do not cross unrelated shapes, container headers, or labels; text is not clipped; decision branches and feedback paths are unambiguous; and adjacent nodes have enough separation. If you change geometry or routing, render again and re-inspect the full diagram because a local fix can create a collision elsewhere.
 
 **Always convert Mermaid to `.drawio` first, then export** — do not export a `.mmd` straight to an image. Direct Mermaid → PNG export with `-e` is broken in current draw.io Desktop (the embedded-XML step crashes); the two-step path (convert, then export the `.drawio`) is reliable and produces an editable embed. See [Troubleshooting](#troubleshooting).
 

--- a/plugins/codex/drawio/skills/drawio/SKILL.md
+++ b/plugins/codex/drawio/skills/drawio/SKILL.md
@@ -35,12 +35,13 @@ Every diagram becomes a native `.drawio` file first, then is delivered in the re
    - **XML**: write the mxGraphModel XML to `diagram.drawio` (see [XML format](#xml-format)). Optionally apply an ELK layout (see [ELK layout for XML](#elk-layout-for-xml)).
 2. **Deliver** (identical for both sources):
    - *(no format)* → keep `diagram.drawio` and open it.
-   - **png / svg / pdf** → export from the `.drawio` with embedded XML, then delete the source `.drawio`:
+   - **png / svg / pdf** → export from the `.drawio` with embedded XML. Keep the source until visual validation passes, then delete it:
      ```bash
      drawio -x -f png -e -b 10 -o diagram.drawio.png diagram.drawio
      ```
    - **url** → build a browser URL from the `.drawio` XML, open it, and keep the `.drawio` as a local copy (see [Browser URL output](#browser-url-output)).
 3. **Open the result** — the exported file, the URL, or the `.drawio`. If the open command fails, print the absolute path (or URL) so the user can open it manually.
+4. **Visually validate non-trivial diagrams** — inspect the rendered result before reporting completion. Confirm that connectors do not cross unrelated shapes, container headers, or labels; text is not clipped; decision branches and feedback paths are unambiguous; and adjacent nodes have enough separation. If you change geometry or routing, render again and re-inspect the full diagram because a local fix can create a collision elsewhere.
 
 **Always convert Mermaid to `.drawio` first, then export** — do not export a `.mmd` straight to an image. Direct Mermaid → PNG export with `-e` is broken in current draw.io Desktop (the embedded-XML step crashes); the two-step path (convert, then export the `.drawio`) is reliable and produces an editable embed. See [Troubleshooting](#troubleshooting).
 

--- a/shared/xml-reference.md
+++ b/shared/xml-reference.md
@@ -471,6 +471,19 @@ The four combinations:
 - The user has asked for specific positions (swim lanes with exact lanes, architecture diagrams with meaningful spatial arrangement).
 - The diagram relies on containers/grouping where spatial layout encodes information.
 
+## Rendered-diagram quality gate
+
+Well-formed XML, valid edge endpoints, and a successful export prove that a diagram can render; they do not prove that the rendered layout is readable. Visually inspect non-trivial diagrams after layout or routing and before delivery.
+
+Check the rendered result for all of the following:
+
+- Connectors do not cross unrelated vertices, container headers, or text labels.
+- Arrowheads and edge labels do not overlap node content or borders, and decision branches are clearly distinguishable.
+- Node labels fit inside their shapes without clipping or unintended wrapping.
+- Adjacent decisions, outcomes, and feedback paths have enough separation to remain unambiguous.
+
+If a check fails, adjust the node placement or routing, render again, and inspect the entire diagram rather than only the edited area. A local routing fix can move the same collision to another node or header.
+
 ## Style reference
 
 Complete style reference (all shape types, style properties, color palettes, HTML labels, and more): https://github.com/jgraph/drawio-mcp/blob/main/shared/style-reference.md


### PR DESCRIPTION
## Problem

- A successful export and valid edge endpoints do not detect rendered connector intersections, clipped labels, or ambiguous decision branches.
- Deleting the source `.drawio` before checking the rendered result makes corrections unnecessarily difficult.
- A local routing adjustment can introduce a new collision elsewhere in the diagram.

## Proposed change

- Keep the source `.drawio` until visual validation passes.
- Add a rendered-diagram quality gate covering connector crossings, label and arrowhead overlap, text clipping, branch clarity, and node separation.
- Require a full-diagram re-render and inspection after geometry or routing changes.

## Validation

- `git diff --check`
- Confirmed the Claude Code and Codex `SKILL.md` copies remain byte-identical.
